### PR TITLE
Fixing FAQ

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -17,9 +17,12 @@
                 {% if application is none %}
                     {% if is_registration_open() and not is_application_open() %}
                         <h2 class="formH2">Applications are not open yet</h2>
-                        <p>{{ hackathon_name }} applications will open soon! Please follow our <a href="https://www.instagram.com/ieee_uoft/" class="hoverLink primaryText" target="_blank">Instagram</a>  for the latest updates.</p>
+                        <p style="margin-bottom: 20px;">{{ hackathon_name }} applications will open soon! Please follow our <a href="https://www.instagram.com/ieee_uoft/" class="hoverLink primaryText" target="_blank">Instagram</a>  for the latest updates.</p>
                         <br />
-                        <p>If you have any questions or concerns, please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a>.</p>
+                        <p style="margin-bottom: 20px;"><b>Note:</b> We are sorry to inform, but due to logistical changes, we will be updating our application form. To those that have previously submitted an application, you would need to refill a new one
+                        when applications re-open. We will be sending an email soon to all those that are affected. Apologies for the inconvenience!</p>
+                        <br />
+                        <p style="margin-bottom: 20px;">If you have any questions or concerns, please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a>.</p>
 
                     {% elif not is_application_open() %}
                         <h2 class="formH2">Applications have closed</h2>

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -284,6 +284,18 @@
                         </li>
                         <li>
                             <div class="collapsible-header">
+                                What is the difference between the registration and application period?
+                            </div>
+                            <div class="collapsible-body">
+                                <span>
+                                    Right now, we are in the registration period. You are only able to register an account for Newhacks.
+                                    Once application period starts (we will announce this on our <a href="https://www.instagram.com/ieee_uoft/" target="_blank">Instagram</a>),
+                                    you will login into your account and fill out the application form.
+                                </span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="collapsible-header">
                                 When can I expect to hear back?
                             </div>
                             <div class="collapsible-body">

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -273,9 +273,13 @@
                                 When is the deadline to apply?
                             </div>
                             <div class="collapsible-body">
-                                <span>
-                                    Applications open on {{ localtime(registration_open_date).strftime('%B %-dth') }} and close on {{ localtime(registration_close_date).strftime('%B %dth at %H:%M, %Y') }}. Acceptances will be internally decided on a rolling basis, so apply early to maximize your chances of getting accepted!
-                                </span>
+{#                                <span>#}
+{#                                    Applications open on {{ localtime(registration_open_date).strftime('%B %-dth') }} and close on {{ localtime(registration_close_date).strftime('%B %dth at %H:%M, %Y') }}. Acceptances will be internally decided on a rolling basis, so apply early to maximize your chances of getting accepted!#}
+{#                                </span>#}
+                                  <span>
+                                      Applications will open end of September and close sometime early-mid October. We are still finalizing the exact date when applications open and close.
+                                      Please follow us on <a href="https://www.instagram.com/ieee_uoft/" target="_blank">Instagram</a> to stay updated and be the first one to know when applications open!
+                                  </span>
                             </div>
                         </li>
                         <li>

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -211,7 +211,8 @@
                             </div>
                             <div class="collapsible-body">
                                 <span>
-                                    Our hackathon is open to high-school or post-secondary students 18 years or older.
+                                    Our hackathon is only open to those who are 18+ <b>or</b> who are attending a post-secondary institution.
+                                    So, if you are in 1st year and are in a post-secondary institution, you are still welcome to apply!
                                 </span>
                             </div>
                         </li>

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -316,7 +316,7 @@ DEFAULT_FROM_EMAIL = "hello@newhacks.ca"
 CONTACT_EMAIL = DEFAULT_FROM_EMAIL
 HSS_ADMIN_EMAIL = "hardware@newhacks.ca"
 
-REGISTRATION_OPEN_DATE = datetime(2024, 9, 3, 0, 0, 0, tzinfo=TZ_INFO)
+REGISTRATION_OPEN_DATE = datetime(2024, 1, 18, 0, 0, 0, tzinfo=TZ_INFO)
 REGISTRATION_CLOSE_DATE = datetime(2024, 10, 11, 23, 59, 0, tzinfo=TZ_INFO)
 APPLICATION_OPEN_DATE = datetime(2025, 10, 1, 0, 0, 0, tzinfo=TZ_INFO)
 EVENT_START_DATE = datetime(2024, 10, 26, 8, 0, 0, tzinfo=TZ_INFO)

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -316,7 +316,7 @@ DEFAULT_FROM_EMAIL = "hello@newhacks.ca"
 CONTACT_EMAIL = DEFAULT_FROM_EMAIL
 HSS_ADMIN_EMAIL = "hardware@newhacks.ca"
 
-REGISTRATION_OPEN_DATE = datetime(2024, 1, 18, 0, 0, 0, tzinfo=TZ_INFO)
+REGISTRATION_OPEN_DATE = datetime(2024, 9, 3, 0, 0, 0, tzinfo=TZ_INFO)
 REGISTRATION_CLOSE_DATE = datetime(2024, 10, 11, 23, 59, 0, tzinfo=TZ_INFO)
 APPLICATION_OPEN_DATE = datetime(2025, 10, 1, 0, 0, 0, tzinfo=TZ_INFO)
 EVENT_START_DATE = datetime(2024, 10, 26, 8, 0, 0, tzinfo=TZ_INFO)


### PR DESCRIPTION
## Overview

This PR updates the landing page to address the following 

- Changing FAQ Page: Clarifying that registration period and application period is different
- Changing FAQ Page: Clarifying that applications are not actually open yet
- Changing FAQ Page: Changing the "Who can Join" FAQ to disallow people under 18 AND those who are not in post-secondary. Ie: Disallowing all high school students from joining. 
- Changing Dashboard page: Clarifying that applications will be shortly deleted, and that participants would need to reapply

